### PR TITLE
Update resource manifests for k8s v1.16

### DIFF
--- a/resource-manifests/kube/ab-testing/sa-frontend-green-deployment.yaml
+++ b/resource-manifests/kube/ab-testing/sa-frontend-green-deployment.yaml
@@ -1,8 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sa-frontend-green
+  labels:
+    app: sa-frontend
 spec:
+  selector:
+    matchLabels:
+      app:  sa-frontend
   replicas: 2
   minReadySeconds: 15
   strategy:

--- a/resource-manifests/kube/sa-feedback-service.yaml
+++ b/resource-manifests/kube/sa-feedback-service.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sa-feedback
   labels:
     app: sa-feedback
 spec:
+  selector:
+    matchLabels:
+      app: sa-feedback
   strategy:
     type: Recreate
   template:

--- a/resource-manifests/kube/sa-frontend-service.yaml
+++ b/resource-manifests/kube/sa-frontend-service.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sa-frontend
   labels:
     app: sa-frontend
 spec:
+  selector:
+    matchLabels:
+      app:  sa-frontend
   replicas: 1
   minReadySeconds: 15
   strategy:

--- a/resource-manifests/kube/sa-logic-service.yaml
+++ b/resource-manifests/kube/sa-logic-service.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sa-logic
   labels:
     app: sa-logic
 spec:
+  selector:
+    matchLabels:
+      app:  sa-logic
   replicas: 2
   minReadySeconds: 15
   strategy:

--- a/resource-manifests/kube/sa-web-app-service.yaml
+++ b/resource-manifests/kube/sa-web-app-service.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sa-web-app
   labels:
-    app: sa-frontend
+    app: sa-web-app
 spec:
+  selector:
+    matchLabels:
+      app:  sa-web-app
   replicas: 1
   minReadySeconds: 15
   strategy:
@@ -45,7 +48,7 @@ kind: Service
 metadata:
   name: sa-web-app
   labels:
-    app: sa-frontend
+    app: sa-web-app
 spec:
   ports:
   - name: http

--- a/resource-manifests/kube/shadowing/sa-logic-service-buggy.yaml
+++ b/resource-manifests/kube/shadowing/sa-logic-service-buggy.yaml
@@ -1,8 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sa-logic-buggy
+  labels:
+    app: sa-logic
 spec:
+  selector:
+    matchLabels:
+      app:  sa-logic
   replicas: 2
   minReadySeconds: 15
   strategy:


### PR DESCRIPTION
Hi @rinormaloku. https://rinormaloku.com/istio-an-introduction/ is a bit outdated: kubectl v1.16 returns an error:
`unable to recognize "resource-manifests/kube/sa-logic-service.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"`

So I fixed resource manifests to get through the tutorial. Here are the changes.